### PR TITLE
Release 1.9.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 # CHANGELOG
 
-## UNRELEASED
-### Added
+## [1.9.3] - 2018-06-22
+### Add
 - Node version 10 support
+
+### Upgrade
+- Update Rubocop to version 0.49 - CVE-2017-8418
 
 ## [1.9.2] - 2018-04-02
 ### Fix

--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,7 @@ end
 
 group :development do
   gem 'spring'
-  gem 'rubocop', '~> 0.38.0', require: false
+  gem 'rubocop', '~> 0.49.0', require: false
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -687,6 +687,7 @@ GEM
     nokogiri (1.8.2)
       mini_portile2 (~> 2.3.0)
     origin (2.3.1)
+    parallel (1.12.1)
     parser (2.5.0.5)
       ast (~> 2.4.0)
     powerpack (0.1.1)
@@ -739,7 +740,8 @@ GEM
       activesupport (= 4.2.10)
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
-    rainbow (2.1.0)
+    rainbow (2.2.2)
+      rake
     rake (12.3.1)
     rdoc (4.3.0)
     redis (4.0.1)
@@ -766,8 +768,9 @@ GEM
       rspec-core (~> 3.0, >= 3.0.0)
       sidekiq (>= 2.4.0)
     rspec-support (3.7.1)
-    rubocop (0.38.0)
-      parser (>= 2.3.0.6, < 3.0)
+    rubocop (0.49.1)
+      parallel (~> 1.10)
+      parser (>= 2.3.3.1, < 3.0)
       powerpack (~> 0.1)
       rainbow (>= 1.99.1, < 3.0)
       ruby-progressbar (~> 1.7)
@@ -852,7 +855,7 @@ DEPENDENCIES
   rspec-context-private
   rspec-rails
   rspec-sidekiq
-  rubocop (~> 0.38.0)
+  rubocop (~> 0.49.0)
   sdoc (~> 0.4.0)
   sidekiq
   simplecov


### PR DESCRIPTION
## [1.9.3] - 2018-06-22
### Add
- Node version 10 support
 
### Upgrade
- Update Rubocop to version 0.49 - CVE-2017-8418