### PR TITLE
Set busbar to proper label apps 'source' and 'service' for Datadog Logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 ### Added
+- Set busbar to proper label apps 'source' and 'service' for Datadog Logs
 - Env variable `BUSBAR_APP` to show the app name
 - Env variable `BUSBAR_ENV` to tell the environment where the app was deployed
 - Env variable `BUSBAR_COMPONENT` to tell the component type from the Procfile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## Unreleased
+### Added
+- Env variable `BUSBAR_APP` to show the app name
+- Env variable `BUSBAR_ENV` to tell the environment where the app was deployed
+- Env variable `BUSBAR_COMPONENT` to tell the component type from the Procfile
+- Env variable `BUSBAR_NODETYPE` to show the currently set nodetype
+
 ## [1.9.7-5] - 2019-07-12
 ### Fixed
 - 'destroy' application method (add checking to not fail in case component doesn't exist)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 ### Added
+- Improve error logging - Add Kubernetes manifest content to error output
 - Set busbar to proper label apps 'source' and 'service' for Datadog Logs
 - Env variable `BUSBAR_APP` to show the app name
 - Env variable `BUSBAR_ENV` to tell the environment where the app was deployed

--- a/app/buildpacks/java_buildpack.rb
+++ b/app/buildpacks/java_buildpack.rb
@@ -3,7 +3,9 @@ class JavaBuildpack
 
   LATEST    = '1.8'.freeze
   SUPPORTED = %w(1.8).freeze
-  TEMPLATE  = 'FROM <%= base_images_registry_url %>/java:<%= java_version %>'.freeze
+  TEMPLATE = [
+    'FROM <%= base_images_registry_url %>/java:<%= java_version %>'
+  ].join("\n").freeze
 
   def compile
     inject_dockerfile

--- a/app/buildpacks/java_buildpack.rb
+++ b/app/buildpacks/java_buildpack.rb
@@ -3,7 +3,7 @@ class JavaBuildpack
 
   LATEST    = '1.8'.freeze
   SUPPORTED = %w(1.8).freeze
-  TEMPLATE = [
+  TEMPLATE  = [
     'FROM <%= base_images_registry_url %>/java:<%= java_version %>'
   ].join("\n").freeze
 

--- a/app/buildpacks/ruby_buildpack.rb
+++ b/app/buildpacks/ruby_buildpack.rb
@@ -1,7 +1,10 @@
 class RubyBuildpack
   include Buildpack
 
-  TEMPLATE = 'FROM <%= base_images_registry_url %>/ruby:<%= ruby_version %>'.freeze
+  TEMPLATE = [
+    'FROM <%= base_images_registry_url %>/ruby:<%= ruby_version %>'
+  ].join("\n").freeze
+
 
   def compile
     inject_dockerfile

--- a/app/models/component/manifest.rb
+++ b/app/models/component/manifest.rb
@@ -31,10 +31,12 @@ class Component
 
     def spec_template
       if Configurations.apps.node_selector.nil?
-        { metadata:     { labels: labels },
+        { metadata:     { labels: labels,
+                          annotations: annotations },
           spec:         { containers: containers } }.with_indifferent_access
       else
-        { metadata:     { labels: labels },
+        { metadata:     { labels: labels,
+                          annotations: annotations },
           spec:         { containers: containers,
                           nodeSelector: { "beta.kubernetes.io/instance-type": \
                                           Configurations.apps.node_selector \
@@ -47,6 +49,10 @@ class Component
         "#{prefix}/environment" => environment.name,
         "#{prefix}/component" => type,
         "#{prefix}/nodetype" => node.id }.with_indifferent_access
+    end
+
+    def annotations
+      { "ad.datadoghq.com/#{name}.logs": '[{"source":"%%env_DATADOG_LOGS_SOURCE%%","service":"%%env_DATADOG_LOGS_SERVICE%%"}]'}.with_indifferent_access
     end
 
     def spec

--- a/app/models/component/manifest.rb
+++ b/app/models/component/manifest.rb
@@ -52,7 +52,13 @@ class Component
     end
 
     def annotations
-      { "ad.datadoghq.com/#{name}.logs": '[{"source":"%%env_DATADOG_LOGS_SOURCE%%","service":"%%env_DATADOG_LOGS_SERVICE%%"}]'}.with_indifferent_access
+      app_string = "[{\"source\":\"#{datadog_logs_source}\",\"service\":\"#{datadog_logs_service}\"}]"
+      if web_component?
+        web_string = "[{\"source\":\"nginx\",\"service\":\"#{datadog_logs_service}\"}]"
+        { "ad.datadoghq.com/#{name}.logs": app_string.to_s, "ad.datadoghq.com/#{name}-nginx.logs": web_string.to_s }.with_indifferent_access
+      else
+        { "ad.datadoghq.com/#{name}.logs": app_string.to_s }.with_indifferent_access
+      end
     end
 
     def spec
@@ -74,6 +80,18 @@ class Component
       port = web_port
       port += 10 if web_component?
       port
+    end
+
+    def java_options
+      settings.fetch('_JAVA_OPTIONS', '-Xmx1280m -Xms1280m').to_s
+    end
+
+    def datadog_logs_service
+      settings.fetch('DATADOG_LOGS_SERVICE', "#{app_id}-#{type}").to_s
+    end
+
+    def datadog_logs_source
+      settings.fetch('DATADOG_LOGS_SOURCE', environment.buildpack_id).to_s
     end
 
     def web_port

--- a/app/models/component/manifest/app_container.rb
+++ b/app/models/component/manifest/app_container.rb
@@ -37,10 +37,13 @@ class Component
         env << { name: '_JAVA_OPTIONS', value: '-Xmx1280m -Xms1280m' }.with_indifferent_access
         env << { name: '_BUSBAR_BUILD_TIME', value: timestamp.to_s }.with_indifferent_access
         env << { name: 'PORT', value: app_port.to_s }.with_indifferent_access
+        env << { name: 'DATADOG_LOGS_SERVICE', value: app_id }.with_indifferent_access
+        env << { name: 'DATADOG_LOGS_SOURCE', value: environment.buildpack_id }.with_indifferent_access
         env << { name: 'BUSBAR_APP', value: app_id }.with_indifferent_access
         env << { name: 'BUSBAR_ENV', value: environment.name }.with_indifferent_access
         env << { name: 'BUSBAR_COMPONENT', value: type }.with_indifferent_access
         env << { name: 'BUSBAR_NODETYPE', value: node.id }.with_indifferent_access
+        env << { name: 'BUSBAR_BUILDPACK', value: environment.buildpack_id }.with_indifferent_access
         env
       end
     end

--- a/app/models/component/manifest/app_container.rb
+++ b/app/models/component/manifest/app_container.rb
@@ -34,11 +34,9 @@ class Component
       def environment_settings
         env = settings.except('PORT')
                       .map { |k, v| { name: k.to_s, value: v.to_s }.with_indifferent_access }
-        env << { name: '_JAVA_OPTIONS', value: '-Xmx1280m -Xms1280m' }.with_indifferent_access
+        env << { name: '_JAVA_OPTIONS', value: java_options.to_s }.with_indifferent_access
         env << { name: '_BUSBAR_BUILD_TIME', value: timestamp.to_s }.with_indifferent_access
         env << { name: 'PORT', value: app_port.to_s }.with_indifferent_access
-        env << { name: 'DATADOG_LOGS_SERVICE', value: app_id }.with_indifferent_access
-        env << { name: 'DATADOG_LOGS_SOURCE', value: environment.buildpack_id }.with_indifferent_access
         env << { name: 'BUSBAR_APP', value: app_id }.with_indifferent_access
         env << { name: 'BUSBAR_ENV', value: environment.name }.with_indifferent_access
         env << { name: 'BUSBAR_COMPONENT', value: type }.with_indifferent_access

--- a/app/models/component/manifest/app_container.rb
+++ b/app/models/component/manifest/app_container.rb
@@ -37,6 +37,10 @@ class Component
         env << { name: '_JAVA_OPTIONS', value: '-Xmx1280m -Xms1280m' }.with_indifferent_access
         env << { name: '_BUSBAR_BUILD_TIME', value: timestamp.to_s }.with_indifferent_access
         env << { name: 'PORT', value: app_port.to_s }.with_indifferent_access
+        env << { name: 'BUSBAR_APP', value: app_id }.with_indifferent_access
+        env << { name: 'BUSBAR_ENV', value: environment.name }.with_indifferent_access
+        env << { name: 'BUSBAR_COMPONENT', value: type }.with_indifferent_access
+        env << { name: 'BUSBAR_NODETYPE', value: node.id }.with_indifferent_access
         env
       end
     end

--- a/app/services/components/installer.rb
+++ b/app/services/components/installer.rb
@@ -34,6 +34,20 @@ module Components
 
       component.log.append_step('Error while installing component')
 
+      component.log.append('Kubernetes Manifest File Content:')
+      component.log.append('---------------------------------')
+
+      fh = open manifest_file.path
+      manifest_content = fh.read
+      fh.close
+
+      require 'json'
+      require 'yaml'
+      manifest_content_hash = JSON.parse(manifest_content)
+      manifest_content_yaml = manifest_content_hash.to_yaml
+
+      component.log.append(manifest_content_yaml)
+
       raise
 
     ensure


### PR DESCRIPTION
This fix the following ticket: https://github.com/busbar-io/busbar-server/issues/46 and add the needed annotations to properly setup Datadog Logs